### PR TITLE
TASK: Add github action to release npm package

### DIFF
--- a/.github/workflows/npm-publish-github-packages.yml
+++ b/.github/workflows/npm-publish-github-packages.yml
@@ -1,0 +1,36 @@
+name: Publish on npm
+
+on:
+  push:
+    tags:
+      - "*.*.*"
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - uses: actions/setup-node@v2
+        with:
+          node-version: 16
+      - run: npm ci
+      - run: npm test
+
+  publish-gpr:
+    needs: build
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: write
+    steps:
+      - uses: actions/checkout@v2
+      - uses: actions/setup-node@v2
+        with:
+          node-version: 16
+          registry-url: https://npm.pkg.github.com/
+      - run: npm ci
+      - run: npm publish
+        env:
+          NODE_AUTH_TOKEN: ${{secrets.GITHUB_TOKEN}}
+
+


### PR DESCRIPTION
As we actually need to release to package manually to NPM we should use a GH action for that when we create a new tag.
For version 1.2.0 for instance, no one did the NPM release. So we used the 6 year old version in the neos-ui.